### PR TITLE
Update build environment

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,6 +27,13 @@ jobs:
       run: dotnet build src/BlackFox.MasterOfFoo.Build/BlackFox.MasterOfFoo.Build.fsproj
     - name: Build
       run: ./build.sh CI
+    - name: Publish artifacts
+      uses: actions/upload-artifact@v6
+      with:
+        path: artifacts/BlackFox.MasterOfFoo/Release/*.nupkg
+        if-no-files-found: error
+        compression-level: 0
+
   windows:
     runs-on: windows-latest
     env:
@@ -47,9 +54,3 @@ jobs:
       run: dotnet build src/BlackFox.MasterOfFoo.Build/BlackFox.MasterOfFoo.Build.fsproj
     - name: Build
       run: ./build.cmd CI
-    - name: Publish artifacts
-      uses: actions/upload-artifact@v6
-      with:
-        path: artifacts/BlackFox.MasterOfFoo/Release/*.nupkg
-        if-no-files-found: error
-        compression-level: 0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   linux:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
       DOTNET_CLI_TELEMETRY_OPTOUT: 1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,8 +15,8 @@ jobs:
       DOTNET_NOLOGO: 1
       PAKET_SKIP_RESTORE_TARGETS: true
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-dotnet@v4
+    - uses: actions/checkout@v6
+    - uses: actions/setup-dotnet@v5
       with:
         dotnet-version: |
           2
@@ -42,8 +42,8 @@ jobs:
       DOTNET_NOLOGO: 1
       PAKET_SKIP_RESTORE_TARGETS: true
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-dotnet@v4
+    - uses: actions/checkout@v6
+    - uses: actions/setup-dotnet@v5
       with:
         dotnet-version: |
           2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   linux:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
       DOTNET_CLI_TELEMETRY_OPTOUT: 1
@@ -47,3 +47,9 @@ jobs:
       run: dotnet build src/BlackFox.MasterOfFoo.Build/BlackFox.MasterOfFoo.Build.fsproj
     - name: Build
       run: ./build.cmd CI
+    - name: Publish artifacts
+      uses: actions/upload-artifact@v6
+      with:
+        path: artifacts/BlackFox.MasterOfFoo/Release/*.nupkg
+        if-no-files-found: error
+        compression-level: 0

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
         "version": "8.0.201",
-        "rollForward": "latestMajor"
+        "rollForward": "minor"
     }
 }


### PR DESCRIPTION
I wanted to start on integration tests, but CI and DX needed some love:

* Stop rollForward in global.json
* CI: Pin ubuntu to a version that can do .NET 5 builds
* CI: Publish the nupkg as artifact
* CI: Update most actions to latest