### PR TITLE
Specify FSharp.Core version 4.5 for net5 builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -247,3 +247,6 @@ launchSettings.json
 .idea/
 
 TestResults.xml
+
+# MSBuild binary logs
+*.binlog

--- a/Release Notes.md
+++ b/Release Notes.md
@@ -1,3 +1,8 @@
+### New in 2.1.1
+
+* Fix FSharp.Core dependency not being specified in the NuGet package for `net5.0` target but the dll being built
+  against 8.0.0 anyway.
+
 ### New in 2.1.0
 
 * Synchronize with the latest FSharp.Core version and support the `%B` format specifier

--- a/src/BlackFox.MasterOfFoo/BlackFox.MasterOfFoo.fsproj
+++ b/src/BlackFox.MasterOfFoo/BlackFox.MasterOfFoo.fsproj
@@ -24,6 +24,7 @@
   <ItemGroup>
     <PackageReference Include="FSharp.Core" Version="4.5.0" Condition="'$(TargetFramework)' == 'net461'" />
     <PackageReference Include="FSharp.Core" Version="4.5.0" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
+    <PackageReference Include="FSharp.Core" Version="4.5.0" Condition="'$(TargetFramework)' == 'net5.0'" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This should fix issue #8

The previous state was for `net5.0`:
- Dll references 8.0.0
- NuGet package doesn't request any version

The new state for `net5.0` is:
- Dll references 4.5.0
- NuGet package requests `>= 4.5.0`